### PR TITLE
ci(-): initially set up CircleCI with build test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - checkout:
           name: "GIT checkout"
       - run:
-          name: "Build"
+          name: "Clean NPM installation"
           command: "npm ci"
       - run:
           name: "Build"


### PR DESCRIPTION
The [initially created config file](4a10611180ee5e57a3b07b59688399391a9f85bd) was just printing `hello world` which I extended to [a build job](https://app.circleci.com/pipelines/github/MrDeerly/vue-timeago3/4/workflows/425c8c1b-8921-4e47-915e-f6ff06e31c7d/jobs/4) which has labelled steps:

1. `Clean NPM installation`
2. `Build` which runs the `build` script from `package.json`

in future this can be enhanced with automated npm publishing (requires the token to be set up as CI variable)
